### PR TITLE
Don't use GLOB in CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,12 @@
-file(GLOB tfhe++_sources "*.cpp")
+SET(tfhe++_sources
+    detwfa.cpp
+    gate.cpp
+    gatebootstrapping.cpp
+    keyswitch.cpp
+    tlwe.cpp
+    trgsw.cpp
+    trlwe.cpp)
+
 
 
 add_library(tfhe++

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,16 @@
-file(GLOB test_sources RELATIVE "${CMAKE_SOURCE_DIR}/test" "*.cpp")
+SET(test_sources
+    circuitbootstrapping.cpp
+    cmux.cpp
+    externalproduct.cpp
+    gate.cpp
+    gatebootstrapping.cpp
+    nand.cpp
+    polymul.cpp
+    rom.cpp
+    tlweenc.cpp
+    trlweenc.cpp
+    write.cpp)
+
 
 foreach(test_source ${test_sources})
     string( REPLACE ".cpp" "" test_name ${test_source} )


### PR DESCRIPTION
`GLOB` doesn't work properly when TFHEpp is treated as sub-project in KVSP.