### PR TITLE
Remove INTorus::operator=

### DIFF
--- a/include/cuhe++.hpp
+++ b/include/cuhe++.hpp
@@ -25,12 +25,6 @@ public:
             value = data;
     }
 
-    INTorus &operator=(const INTorus &a)
-    {
-        this->value = a.value;
-        return *this;
-    }
-
     // return this + b mod P.
     INTorus operator+(const INTorus &b) const
     {


### PR DESCRIPTION
We don't need this. Actually, we shouldn't write it according to [The rule of three](https://en.cppreference.com/w/cpp/language/rule_of_three).