### PR TITLE
add .note.GNU-stack section to remove linker warning

### DIFF
--- a/thirdparties/spqlios/spqlios-fft-avx512.s
+++ b/thirdparties/spqlios/spqlios-fft-avx512.s
@@ -1,4 +1,7 @@
 	.file	"spqlios-fft-avx2.s"
+#if !__APPLE__
+.section .note.GNU-stack,"",%progbits
+#endif
 	.text
 	.p2align 4
 #if !__APPLE__

--- a/thirdparties/spqlios/spqlios-ifft-avx512.s
+++ b/thirdparties/spqlios/spqlios-ifft-avx512.s
@@ -1,4 +1,7 @@
 	.file	"spqlios-ifft-avx.s"
+#if !__APPLE__
+.section .note.GNU-stack,"",%progbits
+#endif
 	.text
 	.p2align 4
 #if !__APPLE__


### PR DESCRIPTION
If I build the library with the following command:
```
md build
cd build
cmake .. -DUSE_AVX512=ON -DENABLE_TEST=ON
make -j
```
Then, the following warning is printed.
```
/usr/bin/ld: warning: spqlios-ifft-avx512.s.o: missing .note.GNU-stack section implies executable stack
/usr/bin/ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
```
I make a patch to prevent the warning.
The modification can be applied to the other asm files.